### PR TITLE
use correct return type macros of dll interface

### DIFF
--- a/explorer/dll.c
+++ b/explorer/dll.c
@@ -20,7 +20,7 @@ const char *program_id = "Git-Cheetah.Application";
  */
 static HINSTANCE hInst;
 
-HRESULT PASCAL DllGetClassObject(REFCLSID obj_guid, REFIID factory_guid,
+HRESULT STDAPICALLTYPE DllGetClassObject(REFCLSID obj_guid, REFIID factory_guid,
 		void **factory_handle)
 {
 	if (IsEqualCLSID(obj_guid, &CLSID_git_shell_ext) ||
@@ -32,7 +32,7 @@ HRESULT PASCAL DllGetClassObject(REFCLSID obj_guid, REFIID factory_guid,
 	return CLASS_E_CLASSNOTAVAILABLE;
 }
 
-HRESULT PASCAL DllCanUnloadNow(void)
+HRESULT STDAPICALLTYPE DllCanUnloadNow(void)
 {
    return (object_count || lock_count) ? S_FALSE : S_OK;
 }

--- a/explorer/dll.h
+++ b/explorer/dll.h
@@ -8,11 +8,11 @@ extern const char *program_name;
 extern const char *program_version;
 extern const char *program_id;
 
-HRESULT PASCAL DllGetClassObject(REFCLSID obj_guid, REFIID factory_guid,
+STDAPI DllGetClassObject(REFCLSID obj_guid, REFIID factory_guid,
 				 void **factory_handle);
-HRESULT PASCAL DllCanUnloadNow(void);
-HRESULT PASCAL DllRegisterServer(void);
-HRESULT PASCAL DllUnregisterServer(void);
+STDAPI DllCanUnloadNow(void);
+STDAPI DllRegisterServer(void);
+STDAPI DllUnregisterServer(void);
 BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, LPVOID reserved);
 
 #endif /* DLL_H */


### PR DESCRIPTION
In commit d1ad8f1 Pat Thoyts corrected the return type macros of the dlls
interface. This was a good change so we add it here again.

---

Probably obviously correct but I though I'd send a pull request for information purposes. I will merge this if nobody objects.
