### PR TITLE
really don't cache environment variables

### DIFF
--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -154,6 +154,9 @@ char *mingw_getcwd(char *pointer, int len);
 char *mingw_getenv(const char *name);
 #define getenv mingw_getenv
 
+int mingw_setenv(const char *name, const char *value, int overwrite);
+#define setenv mingw_setenv
+
 struct hostent *mingw_gethostbyname(const char *host);
 #define gethostbyname mingw_gethostbyname
 

--- a/explorer/systeminfo.c
+++ b/explorer/systeminfo.c
@@ -109,17 +109,15 @@ pid_t fork_process(const char *cmd, const char **args, const char *wd)
 
 	/* if gitpath is set, temporarily set PATH=<gitpath>;%PATH% */
 	if (gitpath) {
-		int len;
 		struct strbuf path = STRBUF_INIT;
 		strbuf_addstr(&path, gitpath);
-		len = GetEnvironmentVariable("PATH", NULL, 0);
-		if (len) {
-			oldpath = malloc(len);
-			GetEnvironmentVariable("PATH", oldpath, len);
+		oldpath = getenv("PATH");
+		if (oldpath) {
+			oldpath = xstrdup(oldpath);
 			strbuf_addch(&path, ';');
 			strbuf_addstr(&path, oldpath);
 		}
-		SetEnvironmentVariable("PATH", path.buf);
+		setenv("PATH", path.buf, 1);
 		strbuf_release(&path);
 	}
 
@@ -128,7 +126,7 @@ pid_t fork_process(const char *cmd, const char **args, const char *wd)
 
 	/* reset PATH to previous value */
 	if (gitpath) {
-		SetEnvironmentVariable("PATH", oldpath);
+		setenv("PATH", oldpath, 1);
 		free(oldpath);
 	}
 	return result;


### PR DESCRIPTION
As of c67941 "don't cache environment variables, fix non-ASCII environment
variables", git-cheetah fails to show context menu items unless the git
installation directory is in the PATH.

This is due to mingw_spawnvpe_cwd using getenv("PATH") internally, which is
the state of the PATH variable as cached by MSVCRT on startup.

To allow for environment changes in the hosting exporer process, we shall
not use any cached variant of the environment.

Reimplement mingw_getenv to access the Win32 environment directly (instead
of MSVCRT's cached version).

Update fork_process to use the improved non-caching getenv instead of the
more complex Win32 function.

Also add a minimal setenv implementation and use it in fork_process, so
that we don't mix POSIX and Win32 APIs.

Reported-by: Peter Oberndorfer kumbayo84@gmail.com
Signed-off-by: Karsten Blees blees@dcon.de
