### PR TITLE
Registry path fix

### DIFF
--- a/explorer/dll.c
+++ b/explorer/dll.c
@@ -190,11 +190,12 @@ static BOOL find_msysgit_in_path()
 	/*
 	 * git.exe is in "\bin\" from what we really need
 	 * the minimal case we can handle is c:\bin\git.exe
-	 * otherwise declare failure
+	 * otherwise declare failure. We additionally check
+	 * for Git for Windows where it is placed in ..\Git\cmd\
 	 */
 	if (file < msysgit + 7)
 		return FALSE;
-	if (strnicmp(file - 5, "\\bin\\", 5))
+	if (strnicmp(file - 5, "\\bin\\", 5) && strnicmp(file - 5, "\\cmd\\", 5))
 		return FALSE;
 	file[-5] = '\0';
 


### PR DESCRIPTION
Git for Windows can add `<Git Folder>/cmd` to the PATH, but msysgit_in_path() expects just `<Git Folder>/bin`.
https://github.com/msysgit/msysgit/blob/master/share/WinGit/install.iss#L1062

This is probably only crucial when you are debugging the dll outside of the git-cheetah folder, having registered it from there, because the only way to get the extension to run is to correct the path in the registry.
