### PR TITLE
Reduce pain points with Visual Studio

### DIFF
--- a/explorer/cheetah.def
+++ b/explorer/cheetah.def
@@ -1,0 +1,8 @@
+LIBRARY
+EXPORTS
+DllMain
+DllRegisterServer PRIVATE
+DllUnregisterServer PRIVATE
+DllCanUnloadNow PRIVATE
+DllGetClassObject PRIVATE
+DllInstall PRIVATE

--- a/explorer/visualstudio/.gitignore
+++ b/explorer/visualstudio/.gitignore
@@ -1,0 +1,12 @@
+Win32
+x64
+*.exp
+*.ilk
+*.lib
+*.pdb
+*.aps
+*.ncb
+*.sln
+*.suo
+*.user
+*.sdf

--- a/explorer/visualstudio/README.txt
+++ b/explorer/visualstudio/README.txt
@@ -1,0 +1,80 @@
+Open the .vcxproj file in any version of Visual Studio from 2010
+onwards. Since 2010 is the lowest supported version and relies on the
+v100 toolset, you may have to upgrade the project file to use the
+toolset installed with your version. You do not need to save the
+IDE-created .sln file, but if you do it is git-ignored anyway. If you
+wish to contribute, please read the CONTRIBUTING section below to
+understand how property changes must be made.
+
+When you build the shell extension the dll will be found at one of
+the following locations, depending on your build environment:
+
+    Win32\Debug\git_shell_ext.dll
+    Win32\Release\git_shell_ext.dll
+
+    x64\Debug\git_shell_ext64.dll
+    x64\Release\git_shell_ext64.dll
+
+To install the shell extension, cd to an above directory and run:
+    regsvr32 git_shell_ext.dll  (or git_shell_ext64.dll)
+
+To uninstall the shell extension run:
+    regsvr32 /u git_shell_ext.dll   (or git_shell_ext64.dll)
+
+Note that when you install your dll, you will overwrite the registry
+entry for the installed version of the extension (if present). To
+re-install it, run regsvr32 from the Git-Cheetah installaton directory.
+For example:
+
+    cd C:\Program Files\Git\git-cheetah
+    regsvr32 git_shell_ext.dll
+
+You must close any File Explorer windows (then reopen them) for the
+extension to be used.
+
+CONTRIBUTING
+Please be aware that parts of the code must compile on Linux and MacOSX.
+Also the .vcxproj file must support different versions of Visual Studio,
+so to ease maintainability we ask you to follow two basic rules:
+
+    1) Property changes must be made using the property sheets. These
+    can be edited from the Property Manager in the IDE or directly at:
+
+        props\Cheetah.Debug.Win32.props
+        props\Cheetah.Debug.x64.props
+        props\Cheetah.Release.Win32.props
+        props\Cheetah.Release.x64.props
+
+    Ensure that you make relevant changes for all configurations.
+
+    2) All references to PlatformToolset in the .vcxproj file must be
+    changed to v100 before you submit your code. You will need to do
+    this if your project file was upgraded.
+
+One way of checking, before you make your final commit, is to open your
+.vcxproj file in a text editor and look for
+    <PropertyGroup Label="Configuration" ..> elements.
+There will be 4 of these, one for each configuration, and you must change
+the PlatformToolset value to v100 in each one.
+
+Next look for unlabelled <PropertyGroup> elements, or any other
+PropertyGroup elements that are not the
+    <PropertyGroup Label="Globals"> block.
+If any are found then you have not followed Rule #1. Transfer these
+properties to the appropriate property sheet then remove the entire
+blocks from the .vcxproj file.
+
+Finally look for any <ItemDefinitionGroup> elements, which will only be
+found if you have not followed Rule #1. Transfer these properties to
+the appropriate property sheet then remove the entire blocks from the
+.vcxproj file.
+
+To summarize the .vcxproj file requirements:
+
+    * there must be one <PropertyGroup Label="Globals"> ... </PropertyGroup>
+    * there must be 4 <PropertyGroup Label="Configuration" ..> elements
+      with PlatformToolset set to v100
+    * there must be no other PropertyGroup elements
+    * there must be no <ItemDefinitionGroup> elements
+    * ToolsVersion must be "4.0", unless changing the lowest
+      supported version

--- a/explorer/visualstudio/cheetah.vcxproj
+++ b/explorer/visualstudio/cheetah.vcxproj
@@ -1,0 +1,119 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{B166694B-D54B-0D5B-704C-C47D52109EB0}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>cheetah</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v100</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v100</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v100</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v100</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="props\Cheetah.Debug.Win32.props" />
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="props\Cheetah.Debug.x64.props" />
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="props\Cheetah.Release.Win32.props" />
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="props\Cheetah.Release.x64.props" />
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\common\cache.h" />
+    <ClInclude Include="..\..\common\cheetahmenu.h" />
+    <ClInclude Include="..\..\common\debug.h" />
+    <ClInclude Include="..\..\common\exec.h" />
+    <ClInclude Include="..\..\common\git-compat-util.h" />
+    <ClInclude Include="..\..\common\hash.h" />
+    <ClInclude Include="..\..\common\menuengine.h" />
+    <ClInclude Include="..\..\common\strbuf.h" />
+    <ClInclude Include="..\..\common\systeminfo.h" />
+    <ClInclude Include="..\..\compat\mingw.h" />
+    <ClInclude Include="..\columns.h" />
+    <ClInclude Include="..\dll.h" />
+    <ClInclude Include="..\ext.h" />
+    <ClInclude Include="..\factory.h" />
+    <ClInclude Include="..\menu.h" />
+    <ClInclude Include="..\registry.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\common\cheetahmenu.c" />
+    <ClCompile Include="..\..\common\date.c" />
+    <ClCompile Include="..\..\common\debug.c" />
+    <ClCompile Include="..\..\common\exec.c" />
+    <ClCompile Include="..\..\common\menuengine.c" />
+    <ClCompile Include="..\..\common\sha1_file.c" />
+    <ClCompile Include="..\..\common\strbuf.c" />
+    <ClCompile Include="..\..\common\usage.c" />
+    <ClCompile Include="..\..\common\wrapper.c" />
+    <ClCompile Include="..\..\compat\mingw.c" />
+    <ClCompile Include="..\..\compat\mmap.c" />
+    <ClCompile Include="..\..\compat\pread.c" />
+    <ClCompile Include="..\..\compat\strlcpy.c" />
+    <ClCompile Include="..\columns.c" />
+    <ClCompile Include="..\dll.c" />
+    <ClCompile Include="..\ext.c" />
+    <ClCompile Include="..\factory.c" />
+    <ClCompile Include="..\menu.c" />
+    <ClCompile Include="..\registry.c" />
+    <ClCompile Include="..\systeminfo.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\cheetah.def" />
+    <None Include="README.txt" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/explorer/visualstudio/cheetah.vcxproj.filters
+++ b/explorer/visualstudio/cheetah.vcxproj.filters
@@ -1,0 +1,132 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="common">
+      <UniqueIdentifier>{5db05708-470b-489f-a89d-23f3bd3a87bf}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="compat">
+      <UniqueIdentifier>{2677eb57-edc5-4b17-a49b-109d13e918b6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="explorer">
+      <UniqueIdentifier>{3da6d38f-2b1b-4a50-ae08-6b633a07d3aa}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\common\cache.h">
+      <Filter>common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\common\cheetahmenu.h">
+      <Filter>common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\common\debug.h">
+      <Filter>common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\common\exec.h">
+      <Filter>common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\common\git-compat-util.h">
+      <Filter>common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\common\hash.h">
+      <Filter>common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\common\menuengine.h">
+      <Filter>common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\common\strbuf.h">
+      <Filter>common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\common\systeminfo.h">
+      <Filter>common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\compat\mingw.h">
+      <Filter>compat</Filter>
+    </ClInclude>
+    <ClInclude Include="..\columns.h">
+      <Filter>explorer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dll.h">
+      <Filter>explorer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ext.h">
+      <Filter>explorer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\factory.h">
+      <Filter>explorer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\menu.h">
+      <Filter>explorer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\registry.h">
+      <Filter>explorer</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\common\cheetahmenu.c">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\common\date.c">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\common\debug.c">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\common\exec.c">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\common\menuengine.c">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\common\sha1_file.c">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\common\strbuf.c">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\common\usage.c">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\common\wrapper.c">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\compat\mingw.c">
+      <Filter>compat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\compat\mmap.c">
+      <Filter>compat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\compat\pread.c">
+      <Filter>compat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\compat\strlcpy.c">
+      <Filter>compat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\columns.c">
+      <Filter>explorer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dll.c">
+      <Filter>explorer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ext.c">
+      <Filter>explorer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\factory.c">
+      <Filter>explorer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\menu.c">
+      <Filter>explorer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\registry.c">
+      <Filter>explorer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\systeminfo.c">
+      <Filter>explorer</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\cheetah.def">
+      <Filter>explorer</Filter>
+    </None>
+    <None Include="README.txt" />
+  </ItemGroup>
+</Project>

--- a/explorer/visualstudio/props/Cheetah.Debug.Win32.props
+++ b/explorer/visualstudio/props/Cheetah.Debug.Win32.props
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\src\</IntDir>
+    <TargetName>git_shell_ext</TargetName>
+    <LinkIncremental>true</LinkIncremental>
+    <EnableManagedIncrementalBuild>true</EnableManagedIncrementalBuild>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;inline=;NO_MMAP;NO_PREAD;NO_STRLCPY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>..\cheetah.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup />
+</Project>

--- a/explorer/visualstudio/props/Cheetah.Debug.x64.props
+++ b/explorer/visualstudio/props/Cheetah.Debug.x64.props
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\src\</IntDir>
+    <TargetName>git_shell_ext$(PlatformArchitecture)</TargetName>
+    <LinkIncremental>true</LinkIncremental>
+    <EnableManagedIncrementalBuild>true</EnableManagedIncrementalBuild>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;inline=;NO_MMAP;NO_PREAD;NO_STRLCPY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>..\cheetah.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup />
+</Project>

--- a/explorer/visualstudio/props/Cheetah.Release.Win32.props
+++ b/explorer/visualstudio/props/Cheetah.Release.Win32.props
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\src\</IntDir>
+    <TargetName>git_shell_ext</TargetName>
+    <LinkIncremental>false</LinkIncremental>
+    <EnableManagedIncrementalBuild>true</EnableManagedIncrementalBuild>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;inline=;NO_MMAP;NO_PREAD;NO_STRLCPY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>..\cheetah.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup />
+</Project>

--- a/explorer/visualstudio/props/Cheetah.Release.x64.props
+++ b/explorer/visualstudio/props/Cheetah.Release.x64.props
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\src\</IntDir>
+    <TargetName>git_shell_ext$(PlatformArchitecture)</TargetName>
+    <LinkIncremental>false</LinkIncremental>
+    <EnableManagedIncrementalBuild>true</EnableManagedIncrementalBuild>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;inline=;NO_MMAP;NO_PREAD;NO_STRLCPY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>..\cheetah.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup />
+</Project>


### PR DESCRIPTION
An initial attempt to make life easier using Visual Studio. The concept is to use a single project file with a minimum supported version (in this case Visual Studio 2010).

Note that this needs to be in a separate directory from the existing vs folder, since the gitignore ignores .sln files. Also a different .def file is required because Visual Studio behaves unpredicatably when the library name doesn't match the output file name for x64 builds.
