### PR TITLE
Detach Git Bash

### DIFF
--- a/common/cheetahmenu.c
+++ b/common/cheetahmenu.c
@@ -149,7 +149,7 @@ static int menu_bash(struct git_data *this_, UINT id)
 		return 0;
 	}
 
-	exec_program_v(wd, NULL, NULL, NORMALMODE, argv);
+	exec_program_v(wd, NULL, NULL, DETACHMODE, argv);
 
 	if (argv_free)
 		argv_free(argv_data);

--- a/common/exec.c
+++ b/common/exec.c
@@ -54,7 +54,7 @@ int exec_program_v(const char *working_directory,
 		return -1;
 	}
 
-	if (!output || !error_output)
+	if ((!output || !error_output) && !(DETACHMODE & flags))
 		devnull = open("/dev/null", O_WRONLY);
 
 	s1 = dup(1);
@@ -65,7 +65,7 @@ int exec_program_v(const char *working_directory,
 		dup2(fdout[1], 1);
 
 		flags |= WAITMODE;
-	} else {
+	} else if (devnull >= 0) {
 		dup2(devnull, 1);
 	}
 
@@ -79,10 +79,11 @@ int exec_program_v(const char *working_directory,
 		dup2(fderr[1], 2);
 
 		flags |= WAITMODE;
-	} else {
+	} else if (devnull >= 0) {
 		dup2(devnull, 2);
 	}
-	close(devnull);
+	if (devnull >= 0)
+		close(devnull);
 
 	pid = fork_process(argv[0], argv, working_directory);
 

--- a/common/exec.h
+++ b/common/exec.h
@@ -2,6 +2,7 @@
 #define NORMALMODE (0)
 #define HIDDENMODE (1 << 0) /* hide any windows, opened by execution */
 #define WAITMODE   (1 << 1) /* wait for execution to complete */
+#define DETACHMODE (1 << 2) /* do *not* wait for execution to complete */
 #define QUIETMODE  (1 << 7) /* don't report any errors to user */
 
 enum {


### PR DESCRIPTION
When called from the Windows Explorer, we must not wait for the
stdout/stderr of Git Bash.

A recent change made for FarManager makes Git Cheetah capture
stderr/stdout even when we are not interested in it, to avoid cluttering
FarManager's precious console. Due to this workaround, Git Bash makes the
Explorer -- Git Cheetah's primary intended consumer -- hang.

Since Git Bash does not output anything to the calling console, let's just
force the detached mode by avoiding the FarManager workaround _just_ for
Git Bash.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
