### PR TITLE
Escaped extra tokens that broke the Git Bash context option.

### DIFF
--- a/explorer/menu.c
+++ b/explorer/menu.c
@@ -184,6 +184,9 @@ static char *convert_directory_format(const char *path)
 		case '(':
 		case ')':
 		case ';':
+		case '&':
+		case '`':
+		case '$':
 		case '\'':
 			*(dst++) = '\\';
 			*(dst++) = *path;


### PR DESCRIPTION
I found a bug where using the right-click context option 'Git Bash' on a path that had the character '&' within it was unescaped, producing an error that'd close Git Bash immediately upon trying to open.

![image](https://cloud.githubusercontent.com/assets/4381949/3563047/7b029cf4-0a1a-11e4-944d-db76408b20a7.png)

**Example:** Path C:\Users\Darth\My Programs\Applications & Programs (Others)\msysgit
![image](https://cloud.githubusercontent.com/assets/4381949/3562877/7c5244fa-0a11-11e4-84d7-b208dd03edc7.png)

Looking into the other usual BASH shell oprators, ` and $ also produced similar problems (albeit more treating $ as a variable). ! worked on its own with no issues, and the other possible tokens such as \* and | are illegal chars on Windows.

I tested it on a custom installation to make sure the fix worked, and that it didn't break anything else.

(This is my first time contributing to another project, so let me know if I'm missing anything else!)
